### PR TITLE
Update group.rb

### DIFF
--- a/app/models/plugins/cama_subscriber/group.rb
+++ b/app/models/plugins/cama_subscriber/group.rb
@@ -1,5 +1,5 @@
 class Plugins::CamaSubscriber::Group < ActiveRecord::Base
-  belongs_to :site, class_name: "CamleonCms::Site", foreign_key: :site_id
+  belongs_to :site, class_name: "CamaleonCms::Site", foreign_key: :site_id
   has_many :item_groups, class_name: 'Plugins::CamaSubscriber::GroupItem'
   has_many :items, class_name: 'Plugins::CamaSubscriber::Item', through: :item_groups
 end


### PR DESCRIPTION
due to spelling mistakes, it raise errors 'NameError (uninitialized constant Plugins::CamaSubscriber::Item::CamleonCms::Site)'
same mistake in item.rb and promotion.rb

